### PR TITLE
galpha2net with user-activated upgrade from florence

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "galphanet/tezos-k8s"]
 	path = galphanet/tezos-k8s
 	url = git@github.com:nicolasochem/tezos-k8s.git
+[submodule "galpha2net/tezos-k8s"]
+	path = galpha2net/tezos-k8s
+	url = git@github.com:nicolasochem/tezos-k8s.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = git@github.com:nicolasochem/tezos-k8s.git
 [submodule "galpha2net/tezos-k8s"]
 	path = galpha2net/tezos-k8s
-	url = git@github.com:nicolasochem/tezos-k8s.git
+	url = git@github.com:tqtezos/tezos-k8s.git

--- a/galpha2net/metadata.yaml
+++ b/galpha2net/metadata.yaml
@@ -1,5 +1,5 @@
-description: First alpha network for protocol G
+description: Second alpha network for protocol G
 public_bootstrap_peers:
-  - galphanet.smartpy.io
-  - galphanet.tezos.co.il
-  - galphanet.kaml.fr
+  - galpha2net.smartpy.io
+  - galpha2net.tezos.co.il
+  - galpha2net.kaml.fr

--- a/galpha2net/metadata.yaml
+++ b/galpha2net/metadata.yaml
@@ -1,0 +1,5 @@
+description: First alpha network for protocol G
+public_bootstrap_peers:
+  - galphanet.smartpy.io
+  - galphanet.tezos.co.il
+  - galphanet.kaml.fr

--- a/galpha2net/values.yaml
+++ b/galpha2net/values.yaml
@@ -1,0 +1,109 @@
+bootstrap_peers: []
+node_config_network:
+  activation_account_name: tqbaker
+  #chain_name: TEZOS_GALPHANET_2021-04-28T15:00:00Z
+  genesis:
+    block: BMFCHw1mv3A71KpTuGD3MoFnkHk9wvTYjUzuR9QqiUumKGFG6pM
+    protocol: PtYuensgYBb3G3x1hLLbCmcav8ue8Kyd2khADcL5LsT5R1hcXex
+    #timestamp: "2021-04-28T15:00:00Z"
+images:
+  #tezos: tezos/tezos:master_0a7fe025_20210428084834
+is_invitation: false
+nodes:
+  baking:
+    tezos-baking-node-0:
+      bake_using_account: tqbaker
+      config:
+        shell:
+          history_mode: archive
+      is_bootstrap_node: true
+  regular: {}
+rpc_auth: false
+zerotier_config:
+  zerotier_network: null
+  zerotier_token: null
+zerotier_in_use: false
+
+full_snapshot_url: null
+rolling_snapshot_url: null
+accounts:
+  ecadlabs:
+    key: edpkvP1NXoo8vhYbPSvXdy466EHoYWBpf6zmjghB2p3DwJPjbB5nsf
+    type: public
+    is_bootstrap_baker_account: true
+    bootstrap_balance: "2500000000000"
+  smartpy:
+    key: edpktv8Advoagbpo5TiyyDnmC1Mqne6vJMaXQ2vvuzUfJnBfMKJmdC
+    type: public
+    is_bootstrap_baker_account: true
+    bootstrap_balance: "2500000000000"
+  bruno:
+    key: edpkuu3jmS3kbaLYTmyVaPHaxowC1KP8fDSrLoJhcvip1Cm2tK5QCd
+    type: public
+    is_bootstrap_baker_account: true
+    bootstrap_balance: "2500000000000"
+  tezosil:
+    key: edpkvQj8r3YigN6QFsDRaKQCoxDNhKK4whDUkFkw6Gom36d86uhEbv
+    type: public
+    is_bootstrap_baker_account: true
+    bootstrap_balance: "2500000000000"
+  pirbo:
+    key: edpkuGH2TWTQ5JrwzBLGRu5is1h7vcv5e5LN45VfqmXS5zaTUMpopH
+    type: public
+    is_bootstrap_baker_account: true
+    bootstrap_balance: "2500000000000"
+  tz1THUNA:
+    # Romain's faucet
+    key: edpkuh3WSwziyd6nXqDXeh48vZHp5ETxFd43EdkbzhmW98BvuLXK81
+    type: public
+    is_bootstrap_baker_account: false
+    bootstrap_balance: "500000000000000"
+
+      #two more accouts added by pulumi (not shown here):
+      # * tq's baker
+      # * tq's faucet
+
+
+activation:
+  protocol_hash: ProtoALphaALphaALphaALphaALphaALphaALphaALphaDdp3zK
+  protocol_parameters:
+    preserved_cycles: 3
+    blocks_per_cycle: 2048
+    blocks_per_commitment: 16
+    blocks_per_roll_snapshot: 128
+    blocks_per_voting_period: 1024
+    time_between_blocks:
+      - "30"
+      - "20"
+    endorsers_per_block: 256
+    hard_gas_limit_per_operation: "1040000"
+    hard_gas_limit_per_block: "10400000"
+    proof_of_work_threshold: "70368744177663"
+    tokens_per_roll: "8000000000"
+    michelson_maximum_type_size: 1000
+    seed_nonce_revelation_tip: "125000"
+    origination_size: 257
+    block_security_deposit: "640000000"
+    endorsement_security_deposit: "2500000"
+    baking_reward_per_endorsement:
+      - "78125"
+      - "11719"
+    endorsement_reward:
+      - "78125"
+      - "11719"
+    cost_per_byte: "250"
+    hard_storage_limit_per_operation: "60000"
+    quorum_min: 2000
+    quorum_max: 7000
+    min_proposal_quorum: 500
+    initial_endorsers: 192
+    delay_per_missing_endorsement: "2"
+    minimal_block_delay: '15'
+    # liquidity baking constants
+    liquidity_baking_subsidy: "2500000"
+    liquidity_baking_sunset_level: 525600
+    liquidity_baking_escape_ema_threshold: 1000000
+  should_include_commitments: true
+
+protocol:
+  command: alpha

--- a/galpha2net/values.yaml
+++ b/galpha2net/values.yaml
@@ -67,7 +67,7 @@ accounts:
     key: edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav
     type: public
     is_bootstrap_baker_account: false
-    bootstrap_balance: "500000000000000"
+    bootstrap_balance: "5000000000000000"
 
 
       #two more accouts added by pulumi (not shown here):

--- a/galpha2net/values.yaml
+++ b/galpha2net/values.yaml
@@ -61,8 +61,9 @@ accounts:
     type: public
     is_bootstrap_baker_account: false
     bootstrap_balance: "500000000000000"
-  liquid_admin:
-    # the admin for the liquidity baking contract
+  tzbtc_admin:
+    # admin for the test token contract that stands in for tzBTC.
+    # (put here to test liquidity baking)
     key: edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav
     type: public
     is_bootstrap_baker_account: false

--- a/galpha2net/values.yaml
+++ b/galpha2net/values.yaml
@@ -61,6 +61,13 @@ accounts:
     type: public
     is_bootstrap_baker_account: false
     bootstrap_balance: "500000000000000"
+  liquid_admin:
+    # the admin for the liquidity baking contract
+    key: edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav
+    type: public
+    is_bootstrap_baker_account: false
+    bootstrap_balance: "500000000000000"
+
 
       #two more accouts added by pulumi (not shown here):
       # * tq's baker

--- a/galpha2net/values.yaml
+++ b/galpha2net/values.yaml
@@ -6,6 +6,9 @@ node_config_network:
     block: BMFCHw1mv3A71KpTuGD3MoFnkHk9wvTYjUzuR9QqiUumKGFG6pM
     protocol: PtYuensgYBb3G3x1hLLbCmcav8ue8Kyd2khADcL5LsT5R1hcXex
     #timestamp: "2021-04-28T15:00:00Z"
+  user_activated_upgrades:
+  - level: 42
+    replacement_protocol: ProtoALphaALphaALphaALphaALphaALphaALphaALphaDdp3zK
 images:
   #tezos: tezos/tezos:master_0a7fe025_20210428084834
 is_invitation: false
@@ -65,7 +68,7 @@ accounts:
 
 
 activation:
-  protocol_hash: ProtoALphaALphaALphaALphaALphaALphaALphaALphaDdp3zK
+  protocol_hash: PsFLorenaUUuikDWvMDr6fGBRG8kt3e3D3fHoXK1j1BFRxeSH4i
   protocol_parameters:
     preserved_cycles: 3
     blocks_per_cycle: 2048
@@ -98,12 +101,9 @@ activation:
     min_proposal_quorum: 500
     initial_endorsers: 192
     delay_per_missing_endorsement: "2"
-    minimal_block_delay: '15'
-    # liquidity baking constants
-    liquidity_baking_subsidy: "2500000"
-    liquidity_baking_sunset_level: 525600
-    liquidity_baking_escape_ema_threshold: 1000000
+    test_chain_duration: "1966080"
   should_include_commitments: true
 
-protocol:
-  command: alpha
+protocols:
+- command: alpha
+- command: 009-FLoren

--- a/galpha2net/values.yaml
+++ b/galpha2net/values.yaml
@@ -10,7 +10,7 @@ node_config_network:
   - level: 42
     replacement_protocol: ProtoALphaALphaALphaALphaALphaALphaALphaALphaDdp3zK
 images:
-  tezos: tezos/tezos:master_b72d7960_20210505211746
+  tezos: tezos/tezos:master_25655e7e_20210506121840
 is_invitation: false
 nodes:
   baking:

--- a/galpha2net/values.yaml
+++ b/galpha2net/values.yaml
@@ -1,16 +1,16 @@
 bootstrap_peers: []
 node_config_network:
   activation_account_name: tqbaker
-  #chain_name: TEZOS_GALPHANET_2021-04-28T15:00:00Z
+  chain_name: TEZOS_GALPHANET_2021-05-06T15:00:00Z
   genesis:
     block: BMFCHw1mv3A71KpTuGD3MoFnkHk9wvTYjUzuR9QqiUumKGFG6pM
     protocol: PtYuensgYBb3G3x1hLLbCmcav8ue8Kyd2khADcL5LsT5R1hcXex
-    #timestamp: "2021-04-28T15:00:00Z"
+    timestamp: "2021-05-06T15:00:00Z"
   user_activated_upgrades:
   - level: 42
     replacement_protocol: ProtoALphaALphaALphaALphaALphaALphaALphaALphaDdp3zK
 images:
-  #tezos: tezos/tezos:master_0a7fe025_20210428084834
+  tezos: tezos/tezos:master_b72d7960_20210505211746
 is_invitation: false
 nodes:
   baking:

--- a/galpha2net/values.yaml
+++ b/galpha2net/values.yaml
@@ -82,7 +82,7 @@ activation:
     blocks_per_cycle: 2048
     blocks_per_commitment: 16
     blocks_per_roll_snapshot: 128
-    blocks_per_voting_period: 1024
+    blocks_per_voting_period: 10240
     time_between_blocks:
       - "30"
       - "20"

--- a/index.ts
+++ b/index.ts
@@ -69,7 +69,7 @@ export class TezosK8s extends pulumi.ComponentResource {
                "key": private_non_baking_key,
                "type": "secret",
                "is_bootstrap_baker_account": false,
-               "bootstrap_balance": "50000000000000"
+               "bootstrap_balance": "500000000000000"
         }
         
         const tezosK8sImages = defaultHelmValues["tezos_k8s_images"]
@@ -333,4 +333,6 @@ const albingresscntlr = new k8s.helm.v2.Chart(
 const private_chain = new TezosK8s("mondaynet", "mondaynet/values.yaml", "mondaynet/tezos-k8s",
                                    private_baking_key, private_non_baking_key, cluster, repo);
 const galphanet_chain = new TezosK8s("galphanet", "galphanet/values.yaml", "galphanet/tezos-k8s",
+                                   private_baking_key, private_non_baking_key, cluster, repo);
+const galpha2net_chain = new TezosK8s("galpha2net", "galpha2net/values.yaml", "galpha2net/tezos-k8s",
                                    private_baking_key, private_non_baking_key, cluster, repo);

--- a/index.ts
+++ b/index.ts
@@ -69,7 +69,7 @@ export class TezosK8s extends pulumi.ComponentResource {
                "key": private_non_baking_key,
                "type": "secret",
                "is_bootstrap_baker_account": false,
-               "bootstrap_balance": "500000000000000"
+               "bootstrap_balance": "5000000000000000"
         }
         
         const tezosK8sImages = defaultHelmValues["tezos_k8s_images"]

--- a/src/release.py
+++ b/src/release.py
@@ -24,11 +24,11 @@ for network in [ f.path for f in os.scandir(".") if f.is_dir() and f.path[:3] !=
     default_bootstrap_peers = network_metadata["public_bootstrap_peers"]
     default_bootstrap_peers.insert(0, f"{network_name}.tznode.net")
 
-    network_config = { "sandboxed_chain_name": "SANDBOXED_TEZOS",
-            "chain_name": node_config_network["chain_name"],
-            "default_bootstrap_peers": default_bootstrap_peers,
-            "genesis": node_config_network["genesis"],
-            "genesis_parameters": {
+    network_config = node_config_network
+    network_config.pop("activation_account_name")
+    network_config["sandboxed_chain_name"] = "SANDBOXED_TEZOS"
+    network_config["default_bootstrap_peers"] = default_bootstrap_peers
+    network_config["genesis_parameters"] = {
                 "values": {
                     "genesis_pubkey": genesis_pubkey
                     }


### PR DESCRIPTION
In this new testnet, we will attempt to upgrade from florence to alpha at block 42.

User-activated upgrade requires coordination between all bakers. This is achieved when all bakers use the `--network` URL hook. This is how it will look like:

```
# curl https://teztnets.xtz/galpha2net | jq
{
  "sandboxed_chain_name": "SANDBOXED_TEZOS",
  "chain_name": "something",
  "default_bootstrap_peers": [
     "something",
  ],
  "genesis": {
    "block": "BMFCHw1mv3A71KpTuGD3MoFnkHk9wvTYjUzuR9QqiUumKGFG6pM",
    "protocol": "PtYuensgYBb3G3x1hLLbCmcav8ue8Kyd2khADcL5LsT5R1hcXex",
    "timestamp": "something"
    "user_activated_upgrades": [
      {
        "level": 42,
        "replacement_protocol": "ProtoALphaALphaALphaALphaALphaALphaALphaALphaDdp3zK"
      }
    ]
  },
  "genesis_parameters": {
    "values": {
      "genesis_pubkey": "edpkuix6Lv8vnrz6uDe1w8uaXY7YktitAxn6EHdy2jdzq5n5hZo94n"
    }
  }
}
```

This way, every baker will be configured to execute the upgrade at block 42. This will require everyone to either use the `--network url` parameter or copy the content to the node config manually.

All bakers will also have to run florence baker+endorser binaries and switch to alpha after block 42. If some of you don't do that, it will take time to reach block 42 but we'll get there anyway. I have added automation in tezos-k8s to start binaries for both protocols.

It will also give you a window of opportunity to push your contracts if you want to see how they perform during f=> g upgrade.

## Constants

Galpha2net requires appropriate constants for emmy*. We tried the user-activated upgrade in isolation with just one baker and observed that these constants are not changing during upgrade from florence to galpha. But the chain becomes twice faster and the new liquidity baking parameters are injected.

Galpha2net therefore does not prove that the number of enrodsements, bond values and reward will upgrade as part of the florence to granada transition. (I guess this transition is hardcoded to only happen on mainnet?)

Constants before block 42:

```
nochem@peck ~/workspace/tezos-k8s () $ curl -s http://localhost:8732/chains/main/blocks/head/context/constants | jq
{
  "proof_of_work_nonce_size": 8,
  "nonce_length": 32,
  "max_anon_ops_per_block": 132,
  "max_operation_data_length": 32768,
  "max_proposals_per_delegate": 20,
  "preserved_cycles": 3,
  "blocks_per_cycle": 2048,
  "blocks_per_commitment": 16,
  "blocks_per_roll_snapshot": 128,
  "blocks_per_voting_period": 1024,
  "time_between_blocks": [
    "30",
    "20"
  ],
  "endorsers_per_block": 256,
  "hard_gas_limit_per_operation": "1040000",
  "hard_gas_limit_per_block": "10400000",
  "proof_of_work_threshold": "70368744177663",
  "tokens_per_roll": "8000000000",
  "michelson_maximum_type_size": 1000,
  "seed_nonce_revelation_tip": "125000",
  "origination_size": 257,
  "block_security_deposit": "640000000",
  "endorsement_security_deposit": "2500000",
  "baking_reward_per_endorsement": [
    "78125",
    "11719"
  ],
  "endorsement_reward": [
    "78125",
    "11719"
  ],
  "cost_per_byte": "250",
  "hard_storage_limit_per_operation": "60000",
  "test_chain_duration": "0",
  "quorum_min": 2000,
  "quorum_max": 7000,
  "min_proposal_quorum": 500,
  "initial_endorsers": 192,
  "delay_per_missing_endorsement": "2"
}
```

Constants after block 42:

```
nochem@peck ~/workspace/tezos-k8s () $ curl -s http://localhost:8732/chains/main/blocks/head/context/constants | jq
{
  "proof_of_work_nonce_size": 8,
  "nonce_length": 32,
  "max_anon_ops_per_block": 132,
  "max_operation_data_length": 32768,
  "max_proposals_per_delegate": 20,
  "preserved_cycles": 3,
  "blocks_per_cycle": 2048,
  "blocks_per_commitment": 16,
  "blocks_per_roll_snapshot": 128,
  "blocks_per_voting_period": 1024,
  "time_between_blocks": [
    "30",
    "20"
  ],
  "endorsers_per_block": 256,
  "hard_gas_limit_per_operation": "1040000",
  "hard_gas_limit_per_block": "5200000",
  "proof_of_work_threshold": "70368744177663",
  "tokens_per_roll": "8000000000",
  "michelson_maximum_type_size": 1000,
  "seed_nonce_revelation_tip": "125000",
  "origination_size": 257,
  "block_security_deposit": "640000000",
  "endorsement_security_deposit": "2500000",
  "baking_reward_per_endorsement": [
    "78125",
    "11719"
  ],
  "endorsement_reward": [
    "78125",
    "52083"
  ],
  "cost_per_byte": "250",
  "hard_storage_limit_per_operation": "60000",
  "quorum_min": 2000,
  "quorum_max": 7000,
  "min_proposal_quorum": 500,
  "initial_endorsers": 192,
  "delay_per_missing_endorsement": "2",
  "minimal_block_delay": "15",
  "liquidity_baking_subsidy": "2500000",
  "liquidity_baking_sunset_level": 525600,
  "liquidity_baking_escape_ema_threshold": 1000000
}
```

The bond values mean we should not run out of money this time.