### PR TITLE
Galpha2net try 2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "galphanet/tezos-k8s"]
 	path = galphanet/tezos-k8s
 	url = git@github.com:nicolasochem/tezos-k8s.git
+[submodule "galpha2net/tezos-k8s"]
+	path = galpha2net/tezos-k8s
+	url = git@github.com:tqtezos/tezos-k8s.git

--- a/galpha2net/metadata.yaml
+++ b/galpha2net/metadata.yaml
@@ -1,0 +1,5 @@
+description: Second alpha network for protocol G
+public_bootstrap_peers:
+  - galpha2net.smartpy.io
+  - galpha2net.tezos.co.il
+  - galpha2net.kaml.fr

--- a/galpha2net/values.yaml
+++ b/galpha2net/values.yaml
@@ -10,7 +10,7 @@ node_config_network:
   - level: 2048
     replacement_protocol: ProtoALphaALphaALphaALphaALphaALphaALphaALphaDdp3zK
 images:
-  tezos: tezos/tezos:master_fe945351_20210506160445
+  tezos: tezos/tezos:master_f581581a_20210507100713
 is_invitation: false
 nodes:
   baking:

--- a/galpha2net/values.yaml
+++ b/galpha2net/values.yaml
@@ -1,0 +1,117 @@
+bootstrap_peers: []
+node_config_network:
+  activation_account_name: tqbaker
+  chain_name: TEZOS_GALPHA2NET_2021-05-07T15:00:00Z
+  genesis:
+    block: BMFCHw1mv3A71KpTuGD3MoFnkHk9wvTYjUzuR9QqiUumKGFG6pM
+    protocol: PtYuensgYBb3G3x1hLLbCmcav8ue8Kyd2khADcL5LsT5R1hcXex
+    timestamp: "2021-05-07T15:00:00Z"
+  user_activated_upgrades:
+  - level: 2048
+    replacement_protocol: ProtoALphaALphaALphaALphaALphaALphaALphaALphaDdp3zK
+images:
+  tezos: tezos/tezos:master_fe945351_20210506160445
+is_invitation: false
+nodes:
+  baking:
+    tezos-baking-node-0:
+      bake_using_account: tqbaker
+      config:
+        shell:
+          history_mode: archive
+      is_bootstrap_node: true
+  regular: {}
+rpc_auth: false
+zerotier_config:
+  zerotier_network: null
+  zerotier_token: null
+zerotier_in_use: false
+
+full_snapshot_url: null
+rolling_snapshot_url: null
+accounts:
+  ecadlabs:
+    key: edpkvP1NXoo8vhYbPSvXdy466EHoYWBpf6zmjghB2p3DwJPjbB5nsf
+    type: public
+    is_bootstrap_baker_account: true
+    bootstrap_balance: "2500000000000"
+  smartpy:
+    key: edpktv8Advoagbpo5TiyyDnmC1Mqne6vJMaXQ2vvuzUfJnBfMKJmdC
+    type: public
+    is_bootstrap_baker_account: true
+    bootstrap_balance: "2500000000000"
+  bruno:
+    key: edpkuu3jmS3kbaLYTmyVaPHaxowC1KP8fDSrLoJhcvip1Cm2tK5QCd
+    type: public
+    is_bootstrap_baker_account: true
+    bootstrap_balance: "2500000000000"
+  tezosil:
+    key: edpkvQj8r3YigN6QFsDRaKQCoxDNhKK4whDUkFkw6Gom36d86uhEbv
+    type: public
+    is_bootstrap_baker_account: true
+    bootstrap_balance: "2500000000000"
+  pirbo:
+    key: edpkuGH2TWTQ5JrwzBLGRu5is1h7vcv5e5LN45VfqmXS5zaTUMpopH
+    type: public
+    is_bootstrap_baker_account: true
+    bootstrap_balance: "2500000000000"
+  tz1THUNA:
+    # Romain's faucet
+    key: edpkuh3WSwziyd6nXqDXeh48vZHp5ETxFd43EdkbzhmW98BvuLXK81
+    type: public
+    is_bootstrap_baker_account: false
+    bootstrap_balance: "500000000000000"
+  tzbtc_admin:
+    # admin for the test token contract that stands in for tzBTC.
+    # (put here to test liquidity baking)
+    key: edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav
+    type: public
+    is_bootstrap_baker_account: false
+    bootstrap_balance: "5000000000000000"
+
+
+      #two more accouts added by pulumi (not shown here):
+      # * tq's baker
+      # * tq's faucet
+
+
+activation:
+  protocol_hash: PsFLorenaUUuikDWvMDr6fGBRG8kt3e3D3fHoXK1j1BFRxeSH4i
+  protocol_parameters:
+    preserved_cycles: 3
+    blocks_per_cycle: 2048
+    blocks_per_commitment: 16
+    blocks_per_roll_snapshot: 128
+    blocks_per_voting_period: 10240
+    time_between_blocks:
+      - "30"
+      - "20"
+    endorsers_per_block: 32
+    hard_gas_limit_per_operation: "1040000"
+    hard_gas_limit_per_block: "10400000"
+    proof_of_work_threshold: "70368744177663"
+    tokens_per_roll: "8000000000"
+    michelson_maximum_type_size: 1000
+    seed_nonce_revelation_tip: "125000"
+    origination_size: 257
+    block_security_deposit: "512000000"
+    endorsement_security_deposit: "64000000"
+    baking_reward_per_endorsement:
+      - "1250000"
+      - "187500"
+    endorsement_reward:
+      - "1250000"
+      - "833333"
+    cost_per_byte: "250"
+    hard_storage_limit_per_operation: "60000"
+    quorum_min: 2000
+    quorum_max: 7000
+    min_proposal_quorum: 500
+    initial_endorsers: 24
+    delay_per_missing_endorsement: "8"
+    test_chain_duration: "1966080"
+  should_include_commitments: true
+
+protocols:
+- command: alpha
+- command: 009-PsFLoren

--- a/index.ts
+++ b/index.ts
@@ -334,3 +334,5 @@ const private_chain = new TezosK8s("mondaynet", "mondaynet/values.yaml", "monday
                                    private_baking_key, private_non_baking_key, cluster, repo);
 const galphanet_chain = new TezosK8s("galphanet", "galphanet/values.yaml", "galphanet/tezos-k8s",
                                    private_baking_key, private_non_baking_key, cluster, repo);
+const galpha2net_chain = new TezosK8s("galpha2net", "galpha2net/values.yaml", "galpha2net/tezos-k8s",
+                                   private_baking_key, private_non_baking_key, cluster, repo);


### PR DESCRIPTION
* the chain was halting when we did user-activated upgrade at block 42,
  instead we will do it at block 2048. Testing in isolation, I was able
  to go to cycle 7 this way without seeing any chain halts.

  The original issue encountered was:

```
May  6 18:47:17.040 - alpha.baking.forge: Error:
May  6 18:47:17.040 - alpha.baking.forge:   Storage error:
May  6 18:47:17.040 - alpha.baking.forge:     Missing key
'cycle/6/roll_snapshot'
```

* set the activation params to florence values for number of
  endorsmenets per block/reward per block and endorsement/bond per block
  and endorsement. Testing in isolation, I observed that these values
  transition to suitable values for granada when the switchover happens.