### PR TITLE
granadanet

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "florencenet/tezos-k8s"]
 	path = florencenet/tezos-k8s
 	url = git@github.com:tqtezos/tezos-k8s.git
+[submodule "granadanet/tezos-k8s"]
+	path = granadanet/tezos-k8s
+	url = git@github.com:nicolasochem/tezos-k8s.git

--- a/granadanet/metadata.yaml
+++ b/granadanet/metadata.yaml
@@ -1,0 +1,6 @@
+description: Long-running testnet for Granada proposal
+public_bootstrap_peers:
+  - granadanet.smartpy.io
+  - granadanet.tezos.co.il
+  - granadanet.kaml.fr
+bootstrap_commitments: commitments.json

--- a/granadanet/values.yaml
+++ b/granadanet/values.yaml
@@ -3,7 +3,7 @@ node_config_network:
   activation_account_name: tqbaker
   chain_name: TEZOS_GRANADANET_2021-05-21T15:00:00Z
   genesis:
-    block: BMFCHw1mv3A71KpTuGD3MoFnkHk9wvTYjUzuR9QqiUumKGFG6pM
+    block: BLockGenesisGenesisGenesisGenesisGenesisd4299hBGVoU
     protocol: PtYuensgYBb3G3x1hLLbCmcav8ue8Kyd2khADcL5LsT5R1hcXex
     timestamp: "2021-05-21T15:00:00Z"
   user_activated_upgrades:

--- a/granadanet/values.yaml
+++ b/granadanet/values.yaml
@@ -61,7 +61,7 @@ accounts:
     is_bootstrap_baker_account: false
     bootstrap_balance: '5000000000000'
   marco:
-    key: edpkuh3WSwziyd6nXqDXeh48vZHp5ETxFd43EdkbzhmW98BvuLXK81
+    key: edpkvMWHXeETjH4i2h2ngkG2y6aVdgtW99pQ3SuHJoWNEPKANzVRLT
     type: public
     is_bootstrap_baker_account: false
     bootstrap_balance: '5000000000000'

--- a/granadanet/values.yaml
+++ b/granadanet/values.yaml
@@ -128,4 +128,4 @@ activation:
 
 protocols:
 - command: 009-PsFLoren
-- command: 010-PsGraNad
+- command: 010-PtGRANAD

--- a/granadanet/values.yaml
+++ b/granadanet/values.yaml
@@ -5,7 +5,7 @@ node_config_network:
   genesis:
     block: BMFCHw1mv3A71KpTuGD3MoFnkHk9wvTYjUzuR9QqiUumKGFG6pM
     protocol: PtYuensgYBb3G3x1hLLbCmcav8ue8Kyd2khADcL5LsT5R1hcXex
-    timestamp: "2021-05-07T15:00:00Z"
+    timestamp: "2021-05-21T15:00:00Z"
   user_activated_upgrades:
   - level: 4095
     replacement_protocol: PsGraNadatF72MEA6sTufJB2uVKtRXbDMbJo7SNzKjAfdx9bP5q

--- a/granadanet/values.yaml
+++ b/granadanet/values.yaml
@@ -20,7 +20,7 @@ nodes:
         shell:
           history_mode: archive
       is_bootstrap_node: true
-  regular: {}
+  regular: null
 rpc_auth: false
 zerotier_config:
   zerotier_network: null
@@ -58,7 +58,7 @@ accounts:
   luke:
     key: p2pk66gP3wq6k9QgNwAgaGLeXc3YFfrxgYdC7cdYuJWAHYBw4hExVHW
     type: public
-    is_bootstrap_baker_account: true
+    is_bootstrap_baker_account: false
     bootstrap_balance: '5000000000000'
   tz1THUNA:
     # Romain's faucet
@@ -122,5 +122,5 @@ activation:
     test_chain_duration: "1966080"
 
 protocols:
+- command: 009-PsFLoren
 - command: alpha
-- command: 010-PsGraNad

--- a/granadanet/values.yaml
+++ b/granadanet/values.yaml
@@ -118,7 +118,7 @@ activation:
     quorum_max: 7000
     min_proposal_quorum: 500
     initial_endorsers: 24
-    delay_per_missing_endorsement: "8"
+    delay_per_missing_endorsement: "4"
     test_chain_duration: "1966080"
 
 protocols:

--- a/granadanet/values.yaml
+++ b/granadanet/values.yaml
@@ -1,0 +1,126 @@
+bootstrap_peers: []
+node_config_network:
+  activation_account_name: tqbaker
+  chain_name: TEZOS_GRANADANET_2021-05-21T15:00:00Z
+  genesis:
+    block: BMFCHw1mv3A71KpTuGD3MoFnkHk9wvTYjUzuR9QqiUumKGFG6pM
+    protocol: PtYuensgYBb3G3x1hLLbCmcav8ue8Kyd2khADcL5LsT5R1hcXex
+    timestamp: "2021-05-07T15:00:00Z"
+  user_activated_upgrades:
+  - level: 4095
+    replacement_protocol: PsGraNadatF72MEA6sTufJB2uVKtRXbDMbJo7SNzKjAfdx9bP5q
+images:
+  tezos: ???
+is_invitation: false
+nodes:
+  baking:
+    tezos-baking-node-0:
+      bake_using_account: tqbaker
+      config:
+        shell:
+          history_mode: archive
+      is_bootstrap_node: true
+  regular: {}
+rpc_auth: false
+zerotier_config:
+  zerotier_network: null
+  zerotier_token: null
+zerotier_in_use: false
+
+full_snapshot_url: null
+rolling_snapshot_url: null
+accounts:
+  ecadlabs:
+    key: edpkvP1NXoo8vhYbPSvXdy466EHoYWBpf6zmjghB2p3DwJPjbB5nsf
+    type: public
+    is_bootstrap_baker_account: true
+    bootstrap_balance: '5000000000000'
+  smartpy:
+    key: edpktv8Advoagbpo5TiyyDnmC1Mqne6vJMaXQ2vvuzUfJnBfMKJmdC
+    type: public
+    is_bootstrap_baker_account: true
+    bootstrap_balance: '5000000000000'
+  bruno:
+    key: edpkuu3jmS3kbaLYTmyVaPHaxowC1KP8fDSrLoJhcvip1Cm2tK5QCd
+    type: public
+    is_bootstrap_baker_account: true
+    bootstrap_balance: '5000000000000'
+  tezosil:
+    key: edpkvQj8r3YigN6QFsDRaKQCoxDNhKK4whDUkFkw6Gom36d86uhEbv
+    type: public
+    is_bootstrap_baker_account: true
+    bootstrap_balance: '5000000000000'
+  pirbo:
+    key: edpkuGH2TWTQ5JrwzBLGRu5is1h7vcv5e5LN45VfqmXS5zaTUMpopH
+    type: public
+    is_bootstrap_baker_account: true
+    bootstrap_balance: '5000000000000'
+  luke:
+    key: p2pk66gP3wq6k9QgNwAgaGLeXc3YFfrxgYdC7cdYuJWAHYBw4hExVHW
+    type: public
+    is_bootstrap_baker_account: true
+    bootstrap_balance: '5000000000000'
+  tz1THUNA:
+    # Romain's faucet
+    key: edpkuh3WSwziyd6nXqDXeh48vZHp5ETxFd43EdkbzhmW98BvuLXK81
+    type: public
+    is_bootstrap_baker_account: false
+    bootstrap_balance: "500000000000000"
+  tzbtc_admin:
+    # admin for the test token contract that stands in for tzBTC.
+    # (put here to test liquidity baking)
+    key: edpkuBknW28nW72KG6RoHtYW7p12T6GKc7nAbwYX5m8Wd9sDVC9yav
+    type: public
+    is_bootstrap_baker_account: false
+    bootstrap_balance: "5000000000000000"
+  tqbaker:
+    bootstrap_balance: '5000000000000'
+    is_bootstrap_baker_account: true
+    type: secret
+    # key injected by pulumi
+  tqfree:
+    bootstrap_balance: '5000000000000000'
+    is_bootstrap_baker_account: false
+    type: secret
+    # key injected by pulumi
+
+
+activation:
+  protocol_hash: PsFLorenaUUuikDWvMDr6fGBRG8kt3e3D3fHoXK1j1BFRxeSH4i
+  protocol_parameters:
+    preserved_cycles: 3
+    blocks_per_cycle: 2048
+    blocks_per_commitment: 16
+    blocks_per_roll_snapshot: 128
+    blocks_per_voting_period: 10240
+    time_between_blocks:
+      - "30"
+      - "20"
+    endorsers_per_block: 32
+    hard_gas_limit_per_operation: "1040000"
+    hard_gas_limit_per_block: "10400000"
+    proof_of_work_threshold: "70368744177663"
+    tokens_per_roll: "8000000000"
+    michelson_maximum_type_size: 1000
+    seed_nonce_revelation_tip: "125000"
+    origination_size: 257
+    block_security_deposit: "512000000"
+    endorsement_security_deposit: "64000000"
+    baking_reward_per_endorsement:
+      - "1250000"
+      - "187500"
+    endorsement_reward:
+      - "1250000"
+      - "833333"
+    cost_per_byte: "250"
+    hard_storage_limit_per_operation: "60000"
+    quorum_min: 2000
+    quorum_max: 7000
+    min_proposal_quorum: 500
+    initial_endorsers: 24
+    delay_per_missing_endorsement: "8"
+    test_chain_duration: "1966080"
+
+protocols:
+- command: alpha
+- command: 010-PsGraNad

--- a/granadanet/values.yaml
+++ b/granadanet/values.yaml
@@ -10,7 +10,7 @@ node_config_network:
   - level: 4095
     replacement_protocol: PsGraNadatF72MEA6sTufJB2uVKtRXbDMbJo7SNzKjAfdx9bP5q
 images:
-  tezos: ???
+  tezos: tezos/tezos:test-release_917437eb_20210521140907
 is_invitation: false
 nodes:
   baking:
@@ -57,6 +57,11 @@ accounts:
     bootstrap_balance: '5000000000000'
   luke:
     key: p2pk66gP3wq6k9QgNwAgaGLeXc3YFfrxgYdC7cdYuJWAHYBw4hExVHW
+    type: public
+    is_bootstrap_baker_account: false
+    bootstrap_balance: '5000000000000'
+  marco:
+    key: edpkuh3WSwziyd6nXqDXeh48vZHp5ETxFd43EdkbzhmW98BvuLXK81
     type: public
     is_bootstrap_baker_account: false
     bootstrap_balance: '5000000000000'
@@ -123,4 +128,4 @@ activation:
 
 protocols:
 - command: 009-PsFLoren
-- command: alpha
+- command: 010-PsGraNad

--- a/granadanet/values.yaml
+++ b/granadanet/values.yaml
@@ -8,7 +8,7 @@ node_config_network:
     timestamp: "2021-05-21T15:00:00Z"
   user_activated_upgrades:
   - level: 4095
-    replacement_protocol: PsGraNadatF72MEA6sTufJB2uVKtRXbDMbJo7SNzKjAfdx9bP5q
+    replacement_protocol: PtGRANADsDU8R9daYKAgWnQYAJ64omN1o3KMGVCykShA97vQbvV
 images:
   tezos: tezos/tezos:test-release_917437eb_20210521140907
 is_invitation: false

--- a/granadanet/values.yaml
+++ b/granadanet/values.yaml
@@ -10,7 +10,7 @@ node_config_network:
   - level: 4095
     replacement_protocol: PtGRANADsDU8R9daYKAgWnQYAJ64omN1o3KMGVCykShA97vQbvV
 images:
-  tezos: tezos/tezos:test-release_917437eb_20210521140907
+  tezos: tezos/tezos:v9.2
 is_invitation: false
 nodes:
   baking:

--- a/index.ts
+++ b/index.ts
@@ -490,5 +490,5 @@ const florencenet_chain = new TezosK8s("florencenet", "florencenoba", "florencen
                                    private_baking_key, private_non_baking_key, cluster, repo);
 const galpha2net_chain = new TezosK8s("galpha2net", "galpha2net", "galpha2net/values.yaml", "galpha2net/metadata.yaml", "galpha2net/tezos-k8s",
                                    private_baking_key, private_non_baking_key, cluster, repo);
-//const granadanet_chain = new TezosK8s("", "granadanet", "granadanet/values.yaml", "granadanet/metadata.yaml", "granadanet/tezos-k8s",
-                                   //private_baking_key, private_non_baking_key, cluster, repo);
+const granadanet_chain = new TezosK8s("granadanet", "granadanet", "granadanet/values.yaml", "granadanet/metadata.yaml", "granadanet/tezos-k8s",
+                                   private_baking_key, private_non_baking_key, cluster, repo);


### PR DESCRIPTION
Specification for granadanet.

`values.yaml` contains the activation parameters. `metadata.yaml` contains the hostnames of the genesis bakers.

Please note:
* we will start off with florence and do a user-activated upgrade to granada at block 4095 (2 cycles in):
  * because of that, the activation parameters that you see below are for florence. this is normal.
  * ~before launch, I will be running single-baker tests to make sure the chain won't halt with these parameters.~ I ran a single-baker simulation which activated the upgrade and went further all the way to block 12000, and still going. There is a good chance these parameters are good and the chain won't halt
  * blocks will be 30 second and will switch to 15 second after granada migration (mainnet blocks will switch from 1 min to 30 sec)
  * cycle length will be 2048 for the first 2 cycles and then double to 4096 (mainnet will similarly double from 4096 to 8192)
* tz3 support should work so Luke should be a genesis baker
* we do not have a docker build yet so the `image` is currently unspecified, I will update this PR with the image when it's available
* I will advertise on the baking slack so more genesis bakers may join
